### PR TITLE
fix(bank): scale resolved balance amounts

### DIFF
--- a/x/bank/keeper/grpc_query.go
+++ b/x/bank/keeper/grpc_query.go
@@ -66,7 +66,7 @@ func (k BaseKeeper) AllBalances(ctx context.Context, req *types.QueryAllBalances
 		func(key collections.Pair[sdk.AccAddress, string], value math.Int) (sdk.Coin, error) {
 			if req.ResolveDenom {
 				if metadata, ok := k.GetDenomMetaData(sdkCtx, key.K2()); ok {
-					return sdk.NewCoin(metadata.Display, value), nil
+					return resolveMetadataDenomCoin(key.K2(), value, metadata), nil
 				}
 			}
 			return sdk.NewCoin(key.K2(), value), nil
@@ -78,6 +78,33 @@ func (k BaseKeeper) AllBalances(ctx context.Context, req *types.QueryAllBalances
 	}
 
 	return &types.QueryAllBalancesResponse{Balances: balances, Pagination: pageRes}, nil
+}
+
+func resolveMetadataDenomCoin(baseDenom string, amount math.Int, metadata types.Metadata) sdk.Coin {
+	for _, unit := range metadata.DenomUnits {
+		if unit.GetDenom() != metadata.Display {
+			continue
+		}
+
+		factor, ok := denomUnitFactor(unit.GetExponent())
+		if !ok || !amount.Mod(factor).IsZero() {
+			return sdk.NewCoin(baseDenom, amount)
+		}
+
+		return sdk.NewCoin(metadata.Display, amount.Quo(factor))
+	}
+
+	return sdk.NewCoin(metadata.Display, amount)
+}
+
+func denomUnitFactor(exponent uint32) (math.Int, bool) {
+	const maxSupportedExponent = 76
+
+	if exponent > maxSupportedExponent {
+		return math.Int{}, false
+	}
+
+	return math.NewIntWithDecimal(1, int(exponent)), true
 }
 
 // SpendableBalances implements a gRPC query handler for retrieving an account's

--- a/x/bank/keeper/grpc_query_test.go
+++ b/x/bank/keeper/grpc_query_test.go
@@ -165,7 +165,75 @@ func (suite *KeeperTestSuite) TestQueryAllBalances() {
 	suite.Require().NoError(err)
 	suite.Equal(res.Balances.Len(), 1)
 	suite.Equal(res.Balances[0].Denom, ibcPath+"/"+ibcBaseDenom)
+	suite.Equal(ibcCoins.Amount, res.Balances[0].Amount)
 	suite.Nil(res.Pagination.NextKey)
+}
+
+func (suite *KeeperTestSuite) TestQueryAllBalancesResolveDenomScalesAmount() {
+	ctx, queryClient := suite.ctx, suite.queryClient
+	_, _, addr := testdata.KeyTestPubAddr()
+
+	suite.mockFundAccount(addr)
+	suite.Require().NoError(testutil.FundAccount(ctx, suite.bankKeeper, addr, sdk.NewCoins(
+		sdk.NewInt64Coin("uakt", 100_000_000_000),
+	)))
+
+	suite.bankKeeper.SetDenomMetaData(ctx, types.Metadata{
+		Description: "Akash token",
+		DenomUnits: []*types.DenomUnit{
+			{
+				Denom:    "uakt",
+				Exponent: 0,
+			},
+			{
+				Denom:    "akt",
+				Exponent: 6,
+			},
+		},
+		Base:    "uakt",
+		Display: "akt",
+		Name:    "Akash",
+		Symbol:  "AKT",
+	})
+
+	req := types.NewQueryAllBalancesRequest(addr, nil, true)
+	res, err := queryClient.AllBalances(gocontext.Background(), req)
+	suite.Require().NoError(err)
+	suite.Require().Len(res.Balances, 1)
+	suite.Equal(sdk.NewInt64Coin("akt", 100_000), res.Balances[0])
+}
+
+func (suite *KeeperTestSuite) TestQueryAllBalancesResolveDenomKeepsBaseDenomWhenAmountIsNotDivisible() {
+	ctx, queryClient := suite.ctx, suite.queryClient
+	_, _, addr := testdata.KeyTestPubAddr()
+
+	baseCoin := sdk.NewInt64Coin("uakt", 6_994_315)
+	suite.mockFundAccount(addr)
+	suite.Require().NoError(testutil.FundAccount(ctx, suite.bankKeeper, addr, sdk.NewCoins(baseCoin)))
+
+	suite.bankKeeper.SetDenomMetaData(ctx, types.Metadata{
+		Description: "Akash token",
+		DenomUnits: []*types.DenomUnit{
+			{
+				Denom:    "uakt",
+				Exponent: 0,
+			},
+			{
+				Denom:    "akt",
+				Exponent: 6,
+			},
+		},
+		Base:    "uakt",
+		Display: "akt",
+		Name:    "Akash",
+		Symbol:  "AKT",
+	})
+
+	req := types.NewQueryAllBalancesRequest(addr, nil, true)
+	res, err := queryClient.AllBalances(gocontext.Background(), req)
+	suite.Require().NoError(err)
+	suite.Require().Len(res.Balances, 1)
+	suite.Equal(baseCoin, res.Balances[0])
 }
 
 func (suite *KeeperTestSuite) TestSpendableBalances() {


### PR DESCRIPTION
# Fix bank balance denom resolution amounts

## Summary

`QueryAllBalancesRequest.ResolveDenom` currently swaps a stored base denom to the metadata display denom, but leaves the amount in base units. On the v2.1.0-rc12 testnet this produced output like:

```yaml
balances:
- amount: "100000000000"
  denom: akt
pagination: {}
```

That balance is really `100000000000uakt`, which is `100000akt`.

This patch makes `AllBalances` use the display unit exponent from bank metadata when denom resolution is requested. If the amount can be represented as an integer display amount, it returns the display denom and scaled amount. If not, it keeps the base denom and base amount, because `sdk.Coin` cannot represent decimal display amounts.

## Behavior

- `100000000000uakt` with display denom `akt` and exponent `6` returns `100000akt`.
- `6994315uakt` stays `6994315uakt`, since `6.994315akt` cannot be represented by `sdk.Coin`.
- If no metadata exists, behavior stays unchanged.
- Existing IBC metadata resolution still returns the resolved display denom when there is no display unit exponent to scale by.

## Tests

```sh
GOWORK=off GOTOOLCHAIN=go1.23.2 go test ./x/bank/keeper -count=1
```

Also built `akash` from the node checkout against this local SDK checkout:

```sh
GOWORK=/Users/chalabi/code/overclock-labs/denom-display-fix/go.work go build -o /tmp/akash-denom-metadata-fix ./cmd/akash
```
